### PR TITLE
Decrease indent at closing braces as language-c does

### DIFF
--- a/settings/language-r.cson
+++ b/settings/language-r.cson
@@ -2,6 +2,7 @@
   'editor':
     'commentStart': '# '
     'foldEndPattern': '(^\\s*\\)|^\\s*\\})'
+    'decreaseIndentPattern': '^\\s*\\}|^\\s*\\)'
 '.text.tex.latex.rd':
   'editor':
     'foldEndPattern': '^\\s*\\}'


### PR DESCRIPTION

Old:
```r
lst %>% purrr::map(~{
  |
  })
```

New:
```r
lst %>% purrr::map(~{
  |
})
```