### PR TITLE
Match shebang to automatically detect language-r package

### DIFF
--- a/grammars/r.cson
+++ b/grammars/r.cson
@@ -7,6 +7,10 @@
   'Rhistory'
 ]
 'name': 'R'
+'firstLineMatch': '''(?x)
+  ^\\#!.*(?:\\s|\\/)Rscript
+  (?:$|\\s)
+'''
 'patterns': [
   {
     'captures':


### PR DESCRIPTION
Right now only shebang is matched, but vim modelines could be added as well (ripped form the language-ruby package)